### PR TITLE
Switch to https to unbreak bootstrap

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -5,12 +5,10 @@
   <default sync-j="4" />
 
   <!-- remotes -->
-  <remote name="jhnc-oss" fetch="git://github.com/jhnc-oss" />
-  <remote name="yocto" fetch="git://git.yoctoproject.org" />
+  <remote name="jhnc-oss" fetch="https://github.com/jhnc-oss" />
 
   <!-- layers -->
-  <project remote="yocto"
-           upstream="dunfell"
+  <project remote="jhnc-oss"
            name="poky"
            path="poky"
            revision="refs/tags/dunfell-23.0.11" />


### PR DESCRIPTION
- unauthenticated git protocol is no longer supported
- limit upstream repositories to our mirrors