### PR TITLE
Add meta-python2-backport layer

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -39,6 +39,11 @@
            revision="dunfell" />
 
   <project remote="jhnc-oss"
+           name="meta-python2-backport"
+           path="meta-python2-backport"
+           revision="main" />
+
+  <project remote="jhnc-oss"
            name="meta-qt5"
            path="meta-qt5"
            revision="dunfell" />
@@ -48,4 +53,3 @@
            path="meta-selinux"
            revision="dunfell" />
 </manifest>
-


### PR DESCRIPTION
Adds `meta-python2-backport`.

Unless https://github.com/jhnc-oss/yocto-build/pull/39 is merged, `dunfell-23.0.13` needs an update with this commit too.