### PR TITLE
Backports for Dunfell

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-2022 jhnc-oss
+Copyright (c) 2021-2023 jhnc-oss
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![ci](https://github.com/jhnc-oss/yocto-manifests/actions/workflows/ci.yml/badge.svg)](https://github.com/jhnc-oss/yocto-manifests/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
 
-Repository manifests for Yocto build.
+Repository manifests of the [**Protos** Yocto distribution](https://github.com/jhnc-oss/protos).
 
 ## Example
 

--- a/default.xml
+++ b/default.xml
@@ -39,6 +39,11 @@
            revision="dunfell" />
 
   <project remote="jhnc-oss"
+           name="meta-python2-backport"
+           path="meta-python2-backport"
+           revision="main" />
+
+  <project remote="jhnc-oss"
            name="meta-qt5"
            path="meta-qt5"
            revision="dunfell" />

--- a/default.xml
+++ b/default.xml
@@ -9,6 +9,16 @@
 
   <!-- layers -->
   <project remote="jhnc-oss"
+           name="protos"
+           path="protos"
+           revision="main" />
+
+  <project remote="jhnc-oss"
+           name="meta-protos"
+           path="meta-protos"
+           revision="main" />
+
+  <project remote="jhnc-oss"
            name="poky"
            path="poky"
            revision="dunfell" />
@@ -27,11 +37,6 @@
            name="meta-openembedded"
            path="meta-oe"
            revision="dunfell" />
-
-  <project remote="jhnc-oss"
-           name="meta-protos"
-           path="meta-protos"
-           revision="main" />
 
   <project remote="jhnc-oss"
            name="meta-python2"

--- a/default.xml
+++ b/default.xml
@@ -54,6 +54,11 @@
            revision="dunfell" />
 
   <project remote="jhnc-oss"
+           name="meta-rust"
+           path="meta-rust"
+           revision="master" />
+
+  <project remote="jhnc-oss"
            name="meta-selinux"
            path="meta-selinux"
            revision="dunfell" />

--- a/default.xml
+++ b/default.xml
@@ -11,12 +11,12 @@
   <project remote="jhnc-oss"
            name="protos"
            path="protos"
-           revision="main" />
+           revision="dunfell" />
 
   <project remote="jhnc-oss"
            name="meta-protos"
            path="meta-protos"
-           revision="main" />
+           revision="dunfell" />
 
   <project remote="jhnc-oss"
            name="poky"

--- a/default.xml
+++ b/default.xml
@@ -31,7 +31,7 @@
   <project remote="jhnc-oss"
            name="meta-protos"
            path="meta-protos"
-           revision="dunfell" />
+           revision="main" />
 
   <project remote="jhnc-oss"
            name="meta-python2"
@@ -48,4 +48,3 @@
            path="meta-selinux"
            revision="dunfell" />
 </manifest>
-


### PR DESCRIPTION
Some backports for Dunfell. The current `dunfell` branch is broken due to some template conf changes not backported yet.